### PR TITLE
Added Romanian language support for TMDB Cinemeta translation

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -10,5 +10,6 @@
     "zh-CN",
     "ko-KR",
     "ar-SA",
-    "hi-IN"
+    "hi-IN",
+    "ro-RO"
 ]

--- a/templates/configure.html
+++ b/templates/configure.html
@@ -88,6 +88,7 @@
                 <option value="ko-KR">🇰🇷 한국어</option>
                 <option value="ar-SA">🇸🇦 العربية</option>
                 <option value="hi-IN">🇮🇳 हिन्दी</option>
+                <option value="ro-RO">🇷🇴 Română</option>
             </select>
 
             <label for="addon-url">🧩 Add Addon from URL</label>

--- a/templates/link_generator.html
+++ b/templates/link_generator.html
@@ -40,6 +40,7 @@
                 <option value="ko-KR">🇰🇷 한국어</option>
                 <option value="ar-SA">🇸🇦 العربية</option>
                 <option value="hi-IN">🇮🇳 हिन्दी</option>
+                <option value="ro-RO">🇷🇴 Română</option>
             </select>
 
 

--- a/translator.py
+++ b/translator.py
@@ -37,7 +37,8 @@ LANGUAGE_FLAGS = {
     "zh-CN": "🇨🇳",
     "ko-KR": "🇰🇷",
     "ar-SA": "🇸🇦",
-    "hi-IN": "🇮🇳"
+    "hi-IN": "🇮🇳",
+    "ro-RO": "🇷🇴"
 }
 
 # For metabuilder
@@ -53,7 +54,8 @@ EPISODE_TRANSLATIONS = {
     "zh-CN": "集",
     "ko-KR": "에피소드",
     "ar-SA": "حلقة",
-    "hi-IN": "एपिसोड"
+    "hi-IN": "एपिसोड",
+    "ro-RO": "Episod"
 }
 
 


### PR DESCRIPTION
This pull request adds support for the Romanian language (`ro-RO`) across the application. The changes ensure that Romanian appears as an option in language selectors, is recognized in the language configuration, and is properly mapped to its flag and translation for "episode".

Language support enhancements:

* Added Romanian (`ro-RO`) to the list of supported languages in `languages.json`.
* Included Romanian as an option in the language selectors in `configure.html` and `link_generator.html`. [[1]](diffhunk://#diff-d9a0533ad45e86c33cdef18372ec54d5b35ba47c8a01420f8848df98f739bf42R91) [[2]](diffhunk://#diff-26d5d6efdfb0b312faf75ea45c293ce99d5f3ed3385ef81a5e84e6c4bb8c4486R43)

Localization updates:

* Mapped the Romanian language code to its flag (`🇷🇴`) in `translator.py`.
* Added the Romanian translation for "episode" ("Episod") in `translator.py`.